### PR TITLE
Update kraken2 database download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You need to install a [Kraken](https://ccb.jhu.edu/software/kraken/) database (~
 You need to install a [Kraken2](https://ccb.jhu.edu/software/kraken2/) database (~8 GB).
 
     wget https://genome-idx.s3.amazonaws.com/kraken/minikraken2_v2_8GB_201904.tgz
-    tar -C $HOME -zxvf minikraken2_v2_8GB_201904_UPDATE.tgz
+    tar -C $HOME -zxvf minikraken2_v2_8GB_201904.tgz
 
 #### Centrifuge
     

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You need to install a [Kraken](https://ccb.jhu.edu/software/kraken/) database (~
 
 You need to install a [Kraken2](https://ccb.jhu.edu/software/kraken2/) database (~8 GB).
 
-    wget ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken2_v2_8GB_201904_UPDATE.tgz
+    wget https://genome-idx.s3.amazonaws.com/kraken/minikraken2_v2_8GB_201904.tgz
     tar -C $HOME -zxvf minikraken2_v2_8GB_201904_UPDATE.tgz
 
 #### Centrifuge


### PR DESCRIPTION
The older link is no longer functional and therefore this PR updates it to a working link that is obtained from [here](https://benlangmead.github.io/aws-indexes/k2#:~:text=.tar.gz-,Minikraken,-v2)